### PR TITLE
Support eslint-plugin-vue@7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,37 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "@babel/core": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
+      "integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.10",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.5",
+        "@babel/parser": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.10",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/eslint-parser": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.12.1.tgz",
@@ -41,11 +72,127 @@
         "eslint-rule-composer": "^0.3.0"
       }
     },
+    "@babel/generator": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+      "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.11",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+      "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/types": "^7.12.11"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+      "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.10"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+      "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.7"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+      "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.10"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+      "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.12.7",
+        "@babel/helper-optimise-call-expression": "^7.12.10",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.11"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+      "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.11"
+      }
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
       "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
+      }
     },
     "@babel/highlight": {
       "version": "7.10.4",
@@ -56,6 +203,70 @@
         "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+      "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.11",
+        "@babel/generator": "^7.12.11",
+        "@babel/helper-function-name": "^7.12.11",
+        "@babel/helper-split-export-declaration": "^7.12.11",
+        "@babel/parser": "^7.12.11",
+        "@babel/types": "^7.12.12",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -646,6 +857,15 @@
         }
       }
     },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1122,6 +1342,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1538,6 +1764,12 @@
         "is-glob": "^4.0.1"
       }
     },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -1631,9 +1863,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "interpret": {
@@ -1730,6 +1962,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -1759,6 +1997,15 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -2517,6 +2764,12 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -2763,6 +3016,12 @@
       "requires": {
         "readable-stream": "3"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,16 +16,17 @@
   ],
   "license": "MIT",
   "peerDependencies": {
+    "@babel/core": "^7.12.10",
     "@babel/eslint-parser": "^7.12.1",
     "@babel/eslint-plugin": "^7.12.1",
-    "@typescript-eslint/eslint-plugin": "4.x",
-    "@typescript-eslint/parser": "4.x",
-    "eslint": "6.x || 7.x",
-    "eslint-plugin-import": "2.x",
-    "eslint-plugin-react": "7.x",
-    "eslint-plugin-react-hooks": "4.x",
-    "eslint-plugin-san": "0.x",
-    "eslint-plugin-vue": "6.x"
+    "@typescript-eslint/eslint-plugin": "^4.11.0",
+    "@typescript-eslint/parser": "^4.11.0",
+    "eslint": "^6.2.0 || 7.x",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-san": "^0.0.1",
+    "eslint-plugin-vue": "^7.3.0"
   },
   "peerDependenciesMeta": {
     "eslint-plugin-import": {
@@ -51,6 +52,7 @@
     }
   },
   "devDependencies": {
+    "@babel/core": "^7.12.10",
     "@babel/eslint-parser": "^7.12.1",
     "@babel/eslint-plugin": "^7.12.1",
     "eslint": "^7.8.1",

--- a/vue/index.js
+++ b/vue/index.js
@@ -106,7 +106,7 @@ module.exports = {
         'vue/this-in-template': 'error',
         'vue/array-bracket-spacing': base['array-bracket-spacing'] || 'off',
         'vue/arrow-spacing': base['arrow-spacing'] || 'off',
-        'vue/block-spacing': base['vue/block-spacing'] || 'off',
+        'vue/block-spacing': base['block-spacing'] || 'off',
         'vue/brace-style': base['brace-style'] || 'off',
         'vue/camelcase': base.camelcase || 'off',
         'vue/comma-dangle': base['comma-dangle'] || 'off',

--- a/vue/index.js
+++ b/vue/index.js
@@ -10,6 +10,7 @@ const v2Rules = {
 };
 
 const v3Rules = {
+    'vue/no-deprecated-data-object-declaration': 'error',
     'vue/no-deprecated-destroyed-lifecycle': 'error',
     'vue/no-deprecated-dollar-listeners-api': 'error',
     'vue/no-deprecated-dollar-scopedslots-api': 'error',

--- a/vue/index.js
+++ b/vue/index.js
@@ -1,4 +1,41 @@
 const {parserOptions, rules: base} = require('../index');
+const version = require('./version');
+
+const v2Rules = {
+    'vue/no-custom-modifiers-on-v-model': 'error',
+    'vue/no-multiple-template-root': 'error',
+    'vue/no-v-for-template-key': 'error',
+    'vue/no-v-model-argument': 'error',
+    'vue/valid-v-bind-sync': 'error',
+};
+
+const v3Rules = {
+    'vue/no-deprecated-destroyed-lifecycle': 'error',
+    'vue/no-deprecated-dollar-listeners-api': 'error',
+    'vue/no-deprecated-dollar-scopedslots-api': 'error',
+    'vue/no-deprecated-events-api': 'error',
+    'vue/no-deprecated-filter': 'error',
+    'vue/no-deprecated-functional-template': 'error',
+    'vue/no-deprecated-html-element-is': 'error',
+    'vue/no-deprecated-inline-template': 'error',
+    'vue/no-deprecated-props-default-this': 'error',
+    'vue/no-deprecated-scope-attribute': 'error',
+    'vue/no-deprecated-slot-attribute': 'error',
+    'vue/no-deprecated-slot-scope-attribute': 'error',
+    'vue/no-deprecated-v-bind-sync': 'error',
+    'vue/no-deprecated-v-on-native-modifier': 'error',
+    'vue/no-deprecated-v-on-number-modifiers': 'error',
+    'vue/no-deprecated-vue-config-keycodes': 'error',
+    'vue/no-lifecycle-after-await': 'error',
+    'vue/no-ref-as-operand': 'error',
+    'vue/no-setup-props-destructure': 'error',
+    'vue/no-v-for-template-key-on-child': 'error',
+    'vue/no-watch-after-await': 'error',
+    'vue/require-slots-as-functions': 'error',
+    'vue/require-toggle-inside-transition': 'error',
+    'vue/return-in-emits-validator': 'error',
+    'vue/valid-v-is': 'error',
+};
 
 module.exports = {
     parser: 'vue-eslint-parser',
@@ -11,19 +48,20 @@ module.exports = {
         {
             files: ['*.vue'],
             rules: {
-                'indent': 'off',
+                indent: 'off',
             },
         },
     ],
     rules: {
         'vue/comment-directive': 'error',
         'vue/jsx-uses-vars': 'error',
+        'vue/no-dupe-v-else-if': 'error',
         'vue/no-dupe-keys': 'error',
         'vue/no-duplicate-attributes': [
             'error',
             {
-                'allowCoexistClass': true,
-                'allowCoexistStyle': true,
+                allowCoexistClass: true,
+                allowCoexistStyle: true,
             },
         ],
         'vue/no-parsing-error': 'error',
@@ -31,15 +69,14 @@ module.exports = {
         'vue/no-shared-component-data': 'error',
         'vue/no-template-key': 'error',
         'vue/no-textarea-mustache': 'error',
-        'vue/no-unused-vars': 'error',
         'vue/no-unused-components': 'error',
+        'vue/no-unused-vars': 'error',
         'vue/no-use-v-if-with-v-for': 'warn',
         'vue/require-prop-type-constructor': 'error',
         'vue/require-render-return': 'error',
         'vue/require-v-for-key': 'error',
         'vue/require-valid-default-prop': 'error',
         'vue/return-in-computed-property': 'error',
-        'vue/use-v-on-exact': 'off',
         'vue/valid-template-root': 'error',
         'vue/valid-v-bind': 'error',
         'vue/valid-v-cloak': 'error',
@@ -53,56 +90,61 @@ module.exports = {
         'vue/valid-v-once': 'error',
         'vue/valid-v-pre': 'error',
         'vue/valid-v-show': 'error',
+        'vue/valid-v-slot': 'error',
         'vue/valid-v-text': 'error',
         'vue/attribute-hyphenation': 'error',
         'vue/html-closing-bracket-newline': 'error',
         'vue/html-closing-bracket-spacing': [
-            'warn', {
-                'selfClosingTag': 'never',
+            'warn',
+            {
+                selfClosingTag: 'never',
             },
         ],
         'vue/html-end-tags': 'error',
-        'vue/html-indent': ['error', 4, {
-            'attribute': 1,
-            'baseIndent': 1,
-            'closeBracket': 0,
-            'alignAttributesVertically': false,
-            'ignores': [],
-        }],
+        'vue/html-indent': [
+            'error',
+            4,
+            {
+                attribute: 1,
+                baseIndent: 1,
+                closeBracket: 0,
+                alignAttributesVertically: false,
+                ignores: [],
+            },
+        ],
         'vue/html-quotes': 'error',
         'vue/html-self-closing': [
             'error',
             {
-                'html': {
-                    'void': 'never',
-                    'normal': 'never',
-                    'component': 'always',
+                html: {
+                    void: 'never',
+                    normal: 'never',
+                    component: 'always',
                 },
-                'svg': 'always',
-                'math': 'always',
+                svg: 'always',
+                math: 'always',
             },
         ],
         'vue/max-attributes-per-line': [
-            'error', {
-                'singleline': 2,
-                'multiline': {
-                    'max': 2,
-                    'allowFirstLine': false,
+            'error',
+            {
+                singleline: 2,
+                multiline: {
+                    max: 2,
+                    allowFirstLine: false,
                 },
             },
         ],
-        'vue/multiline-html-element-content-newline': 'off',
         'vue/mustache-interpolation-spacing': 'error',
-        'vue/name-property-casing': 'off',
         'vue/no-multi-spaces': 'error',
         'vue/no-spaces-around-equal-signs-in-attribute': 'error',
         'vue/prop-name-casing': 'error',
         'vue/require-default-prop': 'error',
         'vue/require-prop-types': 'error',
-        'vue/singleline-html-element-content-newline': 'off',
         'vue/v-bind-style': 'warn',
         'vue/v-on-style': 'warn',
         'vue/attributes-order': 'warn',
+        'vue/no-multiple-slot-args': 'warn',
         'vue/this-in-template': 'error',
         'vue/array-bracket-spacing': base['array-bracket-spacing'] || 'off',
         'vue/arrow-spacing': base['arrow-spacing'] || 'off',
@@ -115,18 +157,14 @@ module.exports = {
             'error',
             'kebab-case',
             {
-                'registeredComponentsOnly': true,
-                'ignores': [],
+                registeredComponentsOnly: true,
+                ignores: [],
             },
         ],
         'vue/component-tags-order': [
             'warn',
             {
-                'order': [
-                    'template',
-                    'script',
-                    'style',
-                ],
+                order: ['template', 'script', 'style'],
             },
         ],
         'vue/dot-location': base['dot-location'] || 'off',
@@ -153,8 +191,6 @@ module.exports = {
         ],
         'vue/space-infix-ops': base['space-infix-ops'] || 'off',
         'vue/space-unary-ops': base['space-unary-ops'] || 'off',
-        'vue/v-slot-style': 'off',
-        'vue/valid-v-bind-sync': 'error',
-        'vue/valid-v-slot': 'error',
+        ...version === 2 ? v2Rules : v3Rules,
     },
 };

--- a/vue/strict.js
+++ b/vue/strict.js
@@ -2,7 +2,6 @@ const defaults = require('./index');
 const version = require('./version');
 
 const v3Rules = {
-    'vue/no-deprecated-data-object-declaration': 'warn',
     'vue/require-explicit-emits': 'error',
 };
 

--- a/vue/strict.js
+++ b/vue/strict.js
@@ -1,9 +1,32 @@
 const defaults = require('./index');
+const version = require('./version');
+
+const v3Rules = {
+    'vue/no-deprecated-data-object-declaration': 'warn',
+    'vue/require-explicit-emits': 'error',
+};
 
 module.exports = {
     ...defaults,
     rules: {
         ...defaults.rules,
+        'vue/no-arrow-functions-in-watch': 'error',
+        'vue/no-mutating-props': 'error',
+        'vue/no-use-v-if-with-v-for': 'error',
+        'vue/v-bind-style': 'error',
+        'vue/v-on-style': 'error',
+        'vue/attributes-order': 'error',
+        'vue/block-tag-newline': 'error',
+        'vue/html-comment-content-newline': 'error',
+        'vue/html-comment-content-spacing': 'error',
+        'vue/html-comment-indent': 'error',
+        'vue/no-duplicate-attr-inheritance': 'error',
+        'vue/no-empty-component-block': 'error',
+        'vue/no-multiple-objects-in-class': 'error',
+        'vue/no-potential-component-option-typo': 'warn',
+        'vue/no-reserved-component-names': 'error',
+        'vue/no-template-target-blank': 'error',
+        'vue/no-useless-v-bind': 'error',
         'vue/no-async-in-computed-properties': 'error',
         'vue/no-side-effects-in-computed-properties': 'error',
         'vue/require-component-is': 'error',
@@ -15,8 +38,9 @@ module.exports = {
         'vue/no-static-inline-styles': 'warn',
         'vue/padding-line-between-blocks': 'error',
         'vue/require-name-property': 'error',
-        'vue/sort-keys': 'off',
-        'vue/static-class-names-order': 'off',
         'vue/v-on-function-call': 'error',
+        'vue/no-lone-template': 'error',
+        'vue/no-multiple-slot-args': 'error',
+        ...version === 3 ? v3Rules : {},
     },
 };

--- a/vue/version.js
+++ b/vue/version.js
@@ -6,23 +6,16 @@
  * @return {2|3|null} version of Vue (only 2 and 3 are currently supported)
  */
 function getVersion() {
-    let Vue = null;
-
     try {
         // eslint-disable-next-line global-require
-        Vue = require('vue');
-    } catch (e) {
+        const {version} = require('vue/package.json');
+        if (version.startsWith('2.')) {
+            return 2;
+        } else if (version.startsWith('3.')) {
+            return 3;
+        }
+    } catch (_) {
         // do nothing
-    }
-
-    if (!Vue || typeof Vue.version !== 'string') {
-        return null;
-    }
-
-    if (Vue.version.startsWith('2.')) {
-        return 2;
-    } else if (Vue.version.startsWith('3.')) {
-        return 3;
     }
 
     return null;
@@ -30,7 +23,7 @@ function getVersion() {
 
 let version = getVersion();
 if (!version) {
-    console.warn('[ecomfe/eslint-config] Vue version is not detected. Assuming Vue 2 is used.');
+    console.warn('[ecomfe/eslint-config] No valid Vue version is detected. Assuming Vue 2 is used.');
     version = 2;
 }
 

--- a/vue/version.js
+++ b/vue/version.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-console */
+
+/**
+ * Detect the version of Vue
+ *
+ * @return {2|3|null} version of Vue (only 2 and 3 are currently supported)
+ */
+function getVersion() {
+    let Vue = null;
+
+    try {
+        // eslint-disable-next-line global-require
+        Vue = require('vue');
+    } catch (e) {
+        // do nothing
+    }
+
+    if (!Vue || typeof Vue.version !== 'string') {
+        return null;
+    }
+
+    if (Vue.version.startsWith('2.')) {
+        return 2;
+    } else if (Vue.version.startsWith('3.')) {
+        return 3;
+    }
+
+    return null;
+}
+
+let version = getVersion();
+if (!version) {
+    console.warn('[ecomfe/eslint-config] Vue version is not detected. Assuming Vue 2 is used.');
+    version = 2;
+}
+
+module.exports = version;


### PR DESCRIPTION
- Support ESLint v7
- Add Vue 3 support (auto-detect version)
- Update version declaration for peer deps
- Fix missing deps for `@babel/core`

Fixes #16.