### PR TITLE
Feat: make react hook independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ module.exports = {
 如果需要检测 React 相关的代码，需要安装相关插件：
 
 ```shell
-npm i -D eslint-plugin-react eslint-plugin-react-hooks
+npm i -D eslint-plugin-react
 ```
 
 并在 `.eslintrc.js` 中引用：
@@ -77,6 +77,24 @@ module.exports = {
 ```
 
 会自动检测本地 React 的版本，默认情况下无需其它配置。
+
+#### hook
+如果项目中有使用 hook, 需要安装相关插件
+
+```shell
+npm i -D eslint-plugin-react-hooks
+```
+
+```js
+module.exports = {
+    extends: [
+        '@ecomfe/eslint-config',
+        '@ecomfe/eslint-config/react/hook',
+        // 或者选择严格模式
+        // '@ecomfe/eslint-config/react/hook-strict',
+    ],
+};
+```
 
 ### Vue
 

--- a/react/hook-strict.js
+++ b/react/hook-strict.js
@@ -1,0 +1,9 @@
+const defaults = require('./hook');
+
+module.exports = {
+    ...defaults,
+    rules: {
+        ...defaults.rules,
+        'react-hooks/exhaustive-deps': 'error',
+    },
+};

--- a/react/hook-strict.js
+++ b/react/hook-strict.js
@@ -1,9 +1,11 @@
 const defaults = require('./hook');
+const strict = require('./strict');
 
 module.exports = {
     ...defaults,
     rules: {
         ...defaults.rules,
+        ...strict.rules,
         'react-hooks/exhaustive-deps': 'error',
     },
 };

--- a/react/hook.js
+++ b/react/hook.js
@@ -1,0 +1,11 @@
+const defaults = require('./index');
+
+module.exports = {
+    ...defaults,
+    plugins: ['react', 'react-hooks'],
+    rules: {
+        ...defaults.rules,
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'warn',
+    },
+};

--- a/react/index.js
+++ b/react/index.js
@@ -1,13 +1,11 @@
 module.exports = {
-    plugins: ['react', 'react-hooks'],
+    plugins: ['react'],
     settings: {
         react: {
             version: 'detect',
         },
     },
     rules: {
-        'react-hooks/rules-of-hooks': 'error',
-        'react-hooks/exhaustive-deps': 'warn',
         'react/default-props-match-prop-types': 'off',
         'react/display-name': 'off',
         'react/forbid-component-props': 'off',

--- a/react/strict.js
+++ b/react/strict.js
@@ -4,7 +4,6 @@ module.exports = {
     ...defaults,
     rules: {
         ...defaults.rules,
-        'react-hooks/exhaustive-deps': 'error',
         'react/forbid-component-props': 'off',
         'react/jsx-handler-names': [
             'off',


### PR DESCRIPTION
有些 React 项目可能还不是 16.8 以上的版本，在使用 `eslint-config`, 还是需要安装 `eslint-plugin-react-hooks`。 所以建议把 hook 规则拆出来，要用hook, 就引入 hook rules.