### PR TITLE
chore: remove no-spaced-func

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ module.exports = {
             },
         ],
         'no-new-object': 'error',
-        'no-spaced-func': 'error',
+        'func-call-spacing': 'error',
         'no-trailing-spaces': 'error',
         'no-extra-parens': 'off',
         'no-mixed-spaces-and-tabs': 'error',

--- a/strict.js
+++ b/strict.js
@@ -190,7 +190,6 @@ module.exports = {
         'no-sequences': 'error',
         'no-shadow': 'off',
         'no-shadow-restricted-names': 'off',
-        'no-spaced-func': 'error',
         'no-sparse-arrays': 'error',
         'no-sync': 'off',
         'no-tabs': 'warn',


### PR DESCRIPTION
no-spaced-func 已经废弃了, 用 func-call-spacing 替代