### PR TITLE
Make Vue config work with TS config

### DIFF
--- a/vue/factory.js
+++ b/vue/factory.js
@@ -262,6 +262,20 @@ const strictRules = {
 };
 
 /**
+ * Try to resolve parser for script blocks
+ * TypeScript > Babel
+ * @returns path for the resolved parser
+ */
+function getParser() {
+    try {
+        return require.resolve('@typescript-eslint/parser');
+    } catch (e) {
+        return require.resolve('@babel/eslint-parser');
+    }
+}
+
+
+/**
  *
  * @param {boolean} strict is strict mode
  * @param {Object} base base JavaScript rules object
@@ -289,7 +303,7 @@ function getConfig(strict, base = {}, version = getVersion(2)) {
         parser: 'vue-eslint-parser',
         parserOptions: {
             ...parserOptions,
-            parser: '@babel/eslint-parser',
+            parser: getParser(),
         },
         plugins: ['vue'],
         overrides: [

--- a/vue/factory.js
+++ b/vue/factory.js
@@ -206,7 +206,7 @@ const basicRules = {
         'vue/no-deprecated-slot-scope-attribute': 'off',
         'vue/no-reserved-component-names': 'error',
         'vue/no-unsupported-features': 'off',
-        'vue/require-direct-export': 'error',
+        'vue/require-direct-export': 'off',
         'vue/script-indent': [
             'error',
             4,


### PR DESCRIPTION
* and turn of `vue/require-direct-export` to allow wrapping export with `defineComponent` for type inference