### PR TITLE
feat: 修改 vue 中 getParser 的方案

### DIFF
--- a/vue/factory.js
+++ b/vue/factory.js
@@ -319,13 +319,13 @@ const strictRules = {
 
 /**
  * Try to resolve parser for script blocks
- * TypeScript > Babel
  * @returns path for the resolved parser
  */
 function getParser() {
-    try {
+    const isTypescriptRepo = fs.existsSync(path.join(process.cwd(), 'tsconfig.json'));
+    if(isTypescriptRepo){
         return require.resolve('@typescript-eslint/parser');
-    } catch (e) {
+    }else{
         return require.resolve('@babel/eslint-parser');
     }
 }


### PR DESCRIPTION
如果当前项目是一个 js 项目，而开发同学错误的安装了 ts parser ，就会导致整个 paser 异常